### PR TITLE
'name' was ignored if it already was a regexp

### DIFF
--- a/src/findtools/find_files.py
+++ b/src/findtools/find_files.py
@@ -93,7 +93,7 @@ class MatchAllPatternsAndTypes(object):
                         )
                 else:
                     # Assume it is already a regexp.
-                    self.name_pattern = name
+                    self.name_patterns.append(name)
         # Initialize private attributes as empty.
         self.__pathname = None
         self.__root = None


### PR DESCRIPTION
Nothing meaningful was done to the 'name' variable if it wasn't an instance of "str". It should be appended to the list of regular expressions `self.name_patterns`